### PR TITLE
Prevent breakage when submitting edit without waiting for budgetlines

### DIFF
--- a/expenses/views.py
+++ b/expenses/views.py
@@ -148,6 +148,10 @@ def edit_expense(request, pk):
         expense_part.save()
         new_ids.append(expense_part.id)
 
+    if (len(new_ids) < 1):
+        messages.warning(request, 'Något gick fel med inladdning av budgetposterna')
+        return HttpResponseRedirect(reverse('expenses-show', kwargs={'pk': pk}))
+
     models.ExpensePart.objects.filter(expense=expense).exclude(id__in=new_ids).delete()
 
     messages.success(request, 'Kvittot ändrades')

--- a/file_api/views.py
+++ b/file_api/views.py
@@ -66,8 +66,10 @@ def new_file(request):
 @csrf_exempt
 def delete_file(request, pk):
     file = File.objects.get(pk=int(pk))
-    if not file.expense == None and not request.user.profile.may_delete(file.expense): 
+    if not file.expense == None and not request.user.profile.may_delete(file.expense):
         return JsonResponse({'Du har inte behörighet att ta bort denna bild.'}, 403)
+    file.expense.confirmed_by = None
+    file.expense.confirmed_at = None
     file.expense = None
     file.save()
 

--- a/templates/expenses/edit.html
+++ b/templates/expenses/edit.html
@@ -141,10 +141,10 @@
 
         <br />
         <input v-for="file in files" v-if="file.status === 1" type="hidden" name="fileIds[]" v-model="file.id" />
-        <button type="submit" v-tooltip="{ content: 'Spara kvittot när allt ser bra ut' }" style="float: right" class="button primary-action theme-color btn-color" v-bind:disabled="files.length === 0 || files.some(x => x.status === 0)">
-            <div v-if="files.length === 0 || files.some(x => x.status === 0)" class="icon spin" style="display: inline-block">
+        <button type="submit" v-tooltip="{ content: 'Spara kvittot när allt ser bra ut' }" style="float: right" class="button primary-action theme-color btn-color" v-bind:disabled="files.length === 0 || files.some(x => x.status === 0) || committees.length == 0">
+            <div v-if="files.length === 0 || files.some(x => x.status === 0) || committees.length == 0" class="icon spin" style="display: inline-block">
                 <i class="fa fa-spinner"></i>
-            </div> 
+            </div>
             Spara och registrera kvitto
         </button>
     </form>


### PR DESCRIPTION
Om man är otålig kan man tydligen submitta en edit utan att ladda in budgetposterna vilket totalt förstör utlägget. Den här PR fixar det på serversidan, samt lägger till lite UX på frontenden. @bullfest 