### PR TITLE
Grant firmatecknare access to delete any expense

### DIFF
--- a/expenses/models.py
+++ b/expenses/models.py
@@ -133,7 +133,8 @@ class Profile(models.Model):
     def may_delete(self, expense):
         if expense.reimbursement:
             return False
-
+        if 'attest-firmatecknare' in dauth.get_permissions(self.user) and expense is not None:
+            return True
         if expense.owner.user.username == self.user.username:
             return True
         for expense_part in expense.expensepart_set.all():


### PR DESCRIPTION
This should probably be refactored in the future. This is only a quickfix which allows the treasurer to delete broken expenses.