### PR TITLE
Inherit methone-links from main.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,18 +1,5 @@
 {% extends "main.html" %}
 
-{% block methone-links %}
-    {str: "Hem", href: "/" },
-    {% if user.is_authenticated %}
-        {str: "Nytt utlägg", href: "/expenses/new/" },
-        {str: "Ny faktura", href: "/invoices/new/" },
-        {str: "Mina utlägg", href: "/users/{{ user.username }}/receipts/" },
-        {% if user.profile.is_admin %}
-            {str: "Administrera", href: "/admin" },
-        {% endif %}
-        {str: "Statistik", href: "/stats"},
-    {% endif %}
-{% endblock %}
-
 {% block app %}
 <div id="welcome">
     <div id="pick">


### PR DESCRIPTION
Instead of overwriting links in topbar - use the inherited ones from main.html. Since they are the same anyway.

Fixes #87 - technically already fixed but this change would also have fixed it.

We discussed this in #88 . To be honest, this doesn't really do anything meaningful in terms of behaviour, it is just a bit of future proofing. This is also how it is done for all other pages.