### PR TITLE
Fix stats page bug

### DIFF
--- a/stats/views.py
+++ b/stats/views.py
@@ -23,9 +23,8 @@ def index(request):
         .order_by('month') \
         .values('month', 'value').all()
     y1 = [x1.filter(month=date(datetime.now().year, i, 1)) for i in range(1, 13)]
-    z1 = [0 if y1[i].count() == 0 else y1[i].get()['value'] for i in range(0, 12)]
+    z1 = [0 if y1[i].count() == 0 else float(y1[i].get()['value']) for i in range(0, 12)]
 
-    print(z1)
     return render(request, 'stats/index.html', {
         'year': models.Expense.objects.filter(reimbursement__isnull=False).aggregate(year=Sum('expensepart__amount'))['year'],
         'highscore': models.Profile.objects.filter(expense__reimbursement__isnull=False).annotate(

--- a/stats/views.py
+++ b/stats/views.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from django.db.models import Sum, Count
-from django.db.models.functions import TruncMonth
+from django.db.models.functions import TruncMonth, Coalesce
 from django.shortcuts import render
 
 from expenses import models
@@ -26,7 +26,7 @@ def index(request):
     z1 = [0 if y1[i].count() == 0 else float(y1[i].get()['value']) for i in range(0, 12)]
 
     return render(request, 'stats/index.html', {
-        'year': models.Expense.objects.filter(reimbursement__isnull=False).aggregate(year=Sum('expensepart__amount'))['year'],
+        'year': models.Expense.objects.filter(reimbursement__isnull=False).aggregate(year=Coalesce(Sum('expensepart__amount'), 0))['year'],
         'highscore': models.Profile.objects.filter(expense__reimbursement__isnull=False).annotate(
             total_amount=Sum('expense__expensepart__amount')
         ).filter(total_amount__gte=0).order_by('-total_amount')[:10],

--- a/templates/stats/index.html
+++ b/templates/stats/index.html
@@ -45,11 +45,7 @@ var config = {
             label: "Antal utlägg",
             backgroundColor: '#278032',
             borderColor: '#278032',
-            data: [
-                {% for m in month_count %}
-                    {{ m }},
-                {% endfor %}
-            ],
+            data: {{ month_count }},
             yAxisID: "A",
             fill: false,
         }, {
@@ -57,11 +53,7 @@ var config = {
             fill: false,
             backgroundColor: '#222',
             borderColor: '#222',
-            data: [
-                {% for m in month_sum %}
-                    {{ m }},
-                {% endfor %}
-            ],
+            data: {{ month_sum }},
             yAxisID: "B",
         }]
     },
@@ -84,7 +76,7 @@ var config = {
                 display: true,
                 scaleLabel: {
                     display: true,
-                    labelString: 'Month'
+                    labelString: 'Månad'
                 }
             }],
             yAxes: [{


### PR DESCRIPTION
This PR fixes a bug on the Stats page. Every other month seems way to low, they weren't 0 but something was wrong.

I found that the issue was basically due to some localization that was being done to represent money with comma as a decimal separator. When that was injected in the template, that turned into separate values in the array used by the graph library instead of single floating point values (as you would expect). So every other month got the kronor-amount and every other got the öre-amount.

`['322428,73', '70426,65', '45788,62', '9709,03', '9334,82', '12929,96', '24246,94', '68040,74', 0, 0, 0, 0]`

would turn into:

```javascript
[
    322428, 73, 
    70426, 65, 
    45788, 62, 
    9709, 03, 
    9334, 82, 
    12929, 96, 
    24246, 94, 
    68040, 74, 
    0, 
    0, 
    0, 
    0
]
```
which resulted in the strange behaviour.

They were represented as `Decimal` values which can be cast to `float`.

This PR is also fixing another minor, but less noticeable, bug. The total sum `Utbetalt i år` could get a `None` value. I made it so you have a fallback of `0` if that is the case. Turning `None kr` into `0 kr`. 
