### PR TITLE
Add wildcard permission for accounting

### DIFF
--- a/expenses/models.py
+++ b/expenses/models.py
@@ -110,7 +110,7 @@ class Profile(models.Model):
 
     # Returns a list of the committees that the user may account for
     def may_account(self, expense=None, invoice=None):
-        if '*' in dauth.get_permissions(self.user) and (expense is not None or invoice is not None):
+        if 'accounting-*' in dauth.get_permissions(self.user) and (expense is not None or invoice is not None):
             return True
 
         may_account = []


### PR DESCRIPTION
This PR fixes #48 

`may_account` was looking for a pls permission called `*` but it is actually called `accounting-*`. Should make it possible to have wildcard accounting permissions.

Changed according to @bullfest comment in #48 and tested with `cashflow.test` in pls: does indeed return `True` with `accounting-*` permission.

