### PR TITLE
Use login.datasektionen.se instead of login2.datasektionen.se

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ TODO: Make sure the packages are up to date/throw out old stuff
 
 The following environment variables are required to run the project:
 
-| Variable              | Description                           | Default                       |
-|-----------------------|---------------------------------------|-------------------------------|
-| DB_URL                | PostgreSQL server url                 | ---                           |
-| DEBUG                 | Django debug mode                     | False                         |
-| SECRET_KEY            | Django encryption key                 | ---                           |
-| LOGIN_KEY            | Login2 API key for KTH authentication | ---                           |
-| S3_BUCKET_NAME        | Amazon AWS s3 bucket name             | ---                           |
-| S3_ACCESS_KEY_ID      | Amazon AWS IAM access key id          | ---                           |
-| S3_SECRET_ACCESS_KEY  | Amazon AWS IAM secret access key      | ---                           |
-| S3_USE_SIGV4          | If Frankfurt, set to False            | True                          |
-| S3_HOST               | Url to s3 server                      | s3.eu-central-1.amazonaws.com |
-| SPAM_API_KEY          | API key for the spam mail system      | ---                           |
+| Variable              | Description                          | Default                       |
+|-----------------------|--------------------------------------|-------------------------------|
+| DB_URL                | PostgreSQL server url                | ---                           |
+| DEBUG                 | Django debug mode                    | False                         |
+| SECRET_KEY            | Django encryption key                | ---                           |
+| LOGIN_KEY             | Login API key for KTH authentication | ---                           |
+| S3_BUCKET_NAME        | Amazon AWS s3 bucket name            | ---                           |
+| S3_ACCESS_KEY_ID      | Amazon AWS IAM access key id         | ---                           |
+| S3_SECRET_ACCESS_KEY  | Amazon AWS IAM secret access key     | ---                           |
+| S3_USE_SIGV4          | If Frankfurt, set to False           | True                          |
+| S3_HOST               | Url to s3 server                     | s3.eu-central-1.amazonaws.com |
+| SPAM_API_KEY          | API key for the spam mail system     | ---                           |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following environment variables are required to run the project:
 | DB_URL                | PostgreSQL server url                 | ---                           |
 | DEBUG                 | Django debug mode                     | False                         |
 | SECRET_KEY            | Django encryption key                 | ---                           |
-| LOGIN2_KEY            | Login2 API key for KTH authentication | ---                           |
+| LOGIN_KEY            | Login2 API key for KTH authentication | ---                           |
 | S3_BUCKET_NAME        | Amazon AWS s3 bucket name             | ---                           |
 | S3_ACCESS_KEY_ID      | Amazon AWS IAM access key id          | ---                           |
 | S3_SECRET_ACCESS_KEY  | Amazon AWS IAM secret access key      | ---                           |

--- a/cashflow/authviews.py
+++ b/cashflow/authviews.py
@@ -4,11 +4,11 @@ from django.http import HttpResponseRedirect, Http404
 
 def login(request):
     """
-    Login route, redirects to login2 login URL.
+    Login route, redirects to the login system.
     """
     if not request.user.is_authenticated:
         return HttpResponseRedirect(
-            'https://login2.datasektionen.se/login?callback=' +
+            'https://login.datasektionen.se/login?callback=' +
             request.scheme + '://' + request.get_host() + '/login/')
     else:
         return HttpResponseRedirect("/")
@@ -16,7 +16,7 @@ def login(request):
 
 def login_with_token(request, token):
     """
-    Handles a login2 redirect and authenticates user.
+    Handles a login redirect and authenticates user.
     """
     if request.method != 'GET':
         raise Http404()

--- a/cashflow/dauth.py
+++ b/cashflow/dauth.py
@@ -10,16 +10,16 @@ from django.http import HttpResponseRedirect
 
 class DAuth(object):
     """
-    Authenticates user through the login2 API.
+    Authenticates user through the login API.
     """
 
     @staticmethod
     def authenticate(token=None):
         """
-        Do the authentication via login2.
+        Do the authentication via the login system.
         Save user in database if did not exist before.
         """
-        url = 'https://login2.datasektionen.se/verify/' + str(token) + '.json?api_key=' + settings.AUTH_API_KEY
+        url = 'https://login.datasektionen.se/verify/' + str(token) + '.json?api_key=' + settings.AUTH_API_KEY
 
         req = requests.get(url)
         if req.status_code == 200:

--- a/cashflow/settings.py
+++ b/cashflow/settings.py
@@ -153,7 +153,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-AUTH_API_KEY = os.getenv('LOGIN2_KEY', 'key-012345678910111213141516171819')
+AUTH_API_KEY = os.getenv('LOGIN_KEY', 'key-012345678910111213141516171819')
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/


### PR DESCRIPTION
This PR removes the use of `login2.datasektionen.se` in favor of `login.datasektionen.se`. This is so we consistently use only one of them.