### PR TITLE
Change format of email content

### DIFF
--- a/templates/email.html
+++ b/templates/email.html
@@ -1,11 +1,9 @@
-{% block content %}
-    # Hej, {{ receiver }}!
-    
-    {% if comment.expense %}
-    Utlägget "[{{ comment.expense.description }}](https://cashflow.datasektionen.se{% url "expenses-show" comment.expense.id %})" har fått en ny kommentar av {{ comment.author }}:
-    {% else %}
-    Fakturan "[{{ comment.invoice.description }}](https://cashflow.datasektionen.se{% url "invoices-show" comment.invoice.id %})" har fått en ny kommentar av {{ comment.author }}:
-    {% endif %}
-    
-    {{ comment.content }}
-{% endblock %}
+# Hej, {{ receiver }}!
+
+{% if comment.expense %}
+Utlägget "[{{ comment.expense.description }}](https://cashflow.datasektionen.se{% url "expenses-show" comment.expense.id %})" har fått en ny kommentar av {{ comment.author }}:
+{% else %}
+Fakturan "[{{ comment.invoice.description }}](https://cashflow.datasektionen.se{% url "invoices-show" comment.invoice.id %})" har fått en ny kommentar av {{ comment.author }}:
+{% endif %}
+
+{{ comment.content }}


### PR DESCRIPTION
The Markdown to HTML formatter used in [spam](https://github.com/datasektionen/spam) seems to have an issue with the way we are sending the content of emails. It seems to interpret it as code or something like that.

From my testing, current behavior when commenting *"content"* on an expense you would send data something like this:

```python
{
    "from": "no-reply@datasektionen.se",
    "to": "juland@kth.se",
    "subject": "Jultomten Andersson har lagt till en kommentar på ditt utlägg.",
    "content": "\n    # Hej, Jultomten Andersson!\n\n    \n    Utlägget \"[Test-utlägg](https://cashflow.datasektionen.se/expenses/4/)\" har fått en ny kommentar av Jultomten Andersson:\n    \n\n    content\n\n",
    "key": "test",
}
```

and get the following email formatting:

```html
<pre><code># Hej, Jultomten Andersson!
 
 
Utlägget "[Test-utlägg](https://cashflow.datasektionen.se/expenses/4/)" har fått en ny kommentar av Jultomten Andersson:
 
 
content
</code></pre>
```

and by doing this change you would send data like this:

```python
{
    "from": "no-reply@datasektionen.se",
    "to": "juland@kth.se",
    "subject": "Jultomten Andersson har lagt till en kommentar på ditt utlägg.",
    "content": "# Hej, Jultomten Andersson!\n\n\nUtlägget \"[Test-utlägg](https://cashflow.datasektionen.se/expenses/4/)\" har fått en ny kommentar av Jultomten Andersson:\n\n\ncontent\n",
    "key": "test",
}
```

and get an email like this:

```html
<h1>Hej, Jultomten Andersson!</h1>
<p>Utlägget "<a href="https://cashflow.datasektionen.se/expenses/4/">Test-utlägg</a>" har fått en ny kommentar av Jultomten Andersson:</p>
<p>content</p>
```

which I'm pretty sure is the intended way.