### PR TITLE
Only show reimbursements for this year

### DIFF
--- a/templates/stats/index.html
+++ b/templates/stats/index.html
@@ -8,7 +8,7 @@
     <header>
         <div class="inner">
             <span class="label">Utbetalt i år</span>
-            <h2>{{ year }} kr</h2>
+            <h2>{{ year|intcomma }} kr</h2>
         </div>
     </header>
     <div id="content">


### PR DESCRIPTION
It says on top of that stats page that we are showing the reimbursements for the current year, but it has been showing all reimbursements ever made.

I also added the `intcomma` formatting to that number and cleaned up the function. 