### PR TITLE
fix word-break on comments

### DIFF
--- a/staticfiles/style.css
+++ b/staticfiles/style.css
@@ -642,6 +642,7 @@ ul.comments li.own .comment {
     color:#fff;
     margin-right: 60px;
     margin-left: auto;
+    word-break: break-all;
 }
 ul.comments li.new .comment {
     padding: 0;


### PR DESCRIPTION
Long words in comments overflows the comment background:
![image](https://user-images.githubusercontent.com/33149910/170101653-426c0b51-5a91-4e85-af2c-4bf61cdb5ecc.png)

This PR adds `word-break: break-all` which fixes this.
![image](https://user-images.githubusercontent.com/33149910/170101771-ea7d1d73-94dd-418c-85d9-341295b69689.png)
