### PR TITLE
Let users with `attest-firmatecknare` attest expenses and invoices for all committees

### DIFF
--- a/expenses/models.py
+++ b/expenses/models.py
@@ -99,7 +99,7 @@ class Profile(models.Model):
                 may_attest.append(permission[len("attest-"):].lower())
         if expense_part is None:
             return may_attest
-        return expense_part.committee_name.lower() in may_attest
+        return 'firmatecknare' in may_attest or expense_part.committee_name.lower() in may_attest
 
     # Returns a list of the committees that the user may pay for
     def may_pay(self):
@@ -302,10 +302,12 @@ class Expense(models.Model):
 
     @staticmethod
     def attestable(may_attest, user):
-        return Expense.objects.exclude(owner__user=user).filter(
-            expensepart__attested_by=None,
-            expensepart__committee_name__iregex=r'(' + '|'.join(may_attest) + ')'
-        ).distinct()
+        filters = {
+            'expensepart__attested_by': None,
+        }
+        if 'firmatecknare' not in may_attest:
+            filters['expensepart__committee_name__iregex'] = r'(' + '|'.join(may_attest) + ')'
+        return Expense.objects.exclude(owner__user=user).filter(**filters).distinct()
 
     @staticmethod
     def confirmable():

--- a/expenses/views.py
+++ b/expenses/views.py
@@ -197,8 +197,15 @@ def get_expense(request, pk):
     if not request.user.profile.may_view_expense(expense):
         return HttpResponseForbidden()
 
+    parts = []
+    for expense_part in expense.expensepart_set.all():
+        part = expense_part.to_dict()
+        part['attestable'] = request.user.profile.may_attest(expense_part)
+        parts.append(part)
+
     return render(request, 'expenses/show.html', {
         'expense': expense,
+        'parts': parts,
         'may_account': request.user.profile.may_account()
     })
 

--- a/invoices/models.py
+++ b/invoices/models.py
@@ -72,7 +72,7 @@ class Invoice(models.Model):
     def is_payable(self):
         if self.payed_at:
             return False
-        for ip in self.invoicepart_set.all(): 
+        for ip in self.invoicepart_set.all():
             if ip.attested_by == None: return False
         return True
 
@@ -89,12 +89,12 @@ class Invoice(models.Model):
 
     @staticmethod
     def attestable(may_attest, user):
-        if '*' in may_attest:
-            return Invoice.objects.filter(invoicepart__attested_by=None).distinct()
-        return Invoice.objects.filter(
-            invoicepart__attested_by=None,
-            invoicepart__committee_name__iregex=r'(' + '|'.join(may_attest) + ')'
-        ).distinct()
+        filters = {
+            'invoicepart__attested_by': None,
+        }
+        if 'firmatecknare' not in may_attest:
+            filters['invoicepart__committee_name__iregex'] = r'(' + '|'.join(may_attest) + ')'
+        return Invoice.objects.filter(**filters).distinct()
 
     # TODO
     @staticmethod

--- a/invoices/views.py
+++ b/invoices/views.py
@@ -95,8 +95,15 @@ def get_invoice(request, pk):
 
     if not request.user.profile.may_view_invoice(invoice): return HttpResponseForbidden()
 
+    parts = []
+    for invoice_part in invoice.invoicepart_set.all():
+        part = invoice_part.to_dict()
+        part['attestable'] = request.user.profile.may_attest(invoice_part)
+        parts.append(part)
+
     return render(request, 'invoices/show.html', {
         'invoice': invoice,
+        'parts': parts,
         'may_account': request.user.profile.may_account()
     })
 

--- a/templates/expenses/show.html
+++ b/templates/expenses/show.html
@@ -44,7 +44,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for expense_part in expense.expensepart_set.all %}
+        {% for expense_part in parts %}
             <tr>
                 <td>
                     <span class="value">{{ expense_part.amount|intcomma }} kr</span>
@@ -66,7 +66,7 @@
                         {{ expense_part.attested_by.user.get_full_name }} ({{ expense_part.attest_date }})
                     </a>
                     {% else %}
-                        {% if expense.owner.user.username != user.username and expense_part.committee_name|lower in user.profile.may_attest %}
+                        {% if expense.owner.user.username != user.username and expense_part.attestable %}
                             <span style="display: block;">
                                 <form method="POST" action="{% url 'admin-expensepart-attest' expense_part.id %}">
                                     {% csrf_token %}

--- a/templates/invoices/show.html
+++ b/templates/invoices/show.html
@@ -53,7 +53,7 @@
             </tr>
         </thead>
         <tbody>
-        {% for invoice_part in invoice.invoicepart_set.all %}
+        {% for invoice_part in parts %}
             <tr>
                 <td>
                     <span class="value">{{ invoice_part.amount|intcomma }} kr</span>
@@ -75,7 +75,7 @@
                         {{ invoice_part.attested_by.user.get_full_name }} ({{ invoice_part.attest_date }})
                     </a>
                     {% else %}
-                        {% if invoice_part.committee_name|lower in user.profile.may_attest %}
+                        {% if invoice_part.attestable %}
                             <span style="display: block;">
                                 <form method="POST" action="{% url 'admin-invoicepart-attest' invoice_part.id %}">
                                     {% csrf_token %}


### PR DESCRIPTION
Currently the `cashflow.firmatecknare` group in pls has `attest-COMMITTEE` rights for all committees and projects. This is both unnecessary and carries the risk of forgetting to give firmatecknare rights to attest for new projects (which has happened and (almost?) got problematic).

There is a `attest-firmatecknare` right, which seems to be used at some places, but not enough places. This PR makes users with `attest-firmatecknare` able to see expenses and invoices for all committees as well as attest them.

I noticed that there are a few places where `attest-*` is checked, which doesn't exist in pls (citation needed). Perhaps these should be removed or replaced by `attest-firmatecknare`? Though I must say that `attest-*` is a better name.