### PR TITLE
Fix 500 error when viewing an expense ant not having permission to pay

### DIFF
--- a/expenses/models.py
+++ b/expenses/models.py
@@ -161,7 +161,7 @@ class Profile(models.Model):
         if expense.owner.user.username == self.user.username or self.may_pay():
             return True
         for committee in expense.committees():
-            if committee.lower() in self.may_account() or committee.lower() in self.may_attest():
+            if committee['committee_name'].lower() in self.may_account() or committee['committee_name'].lower() in self.may_attest():
                 return True
 
         return False
@@ -170,7 +170,7 @@ class Profile(models.Model):
         if invoice.owner.user.username == self.user.username or self.may_pay():
             return True
         for committee in invoice.committees():
-            if committee.lower() in self.may_account() or committee.lower() in self.may_attest():
+            if committee['committee_name'].lower() in self.may_account() or committee['committee_name'].lower() in self.may_attest():
                 return True
 
         return False


### PR DESCRIPTION
This bug must have existed for at least ~6 years, but the statements in question are not run for someone with the `pay` permission, which is why i guess it hasn't been encountered.