### PR TITLE
Also show committees with only invoices in filters

### DIFF
--- a/templates/admin/account/overview.html
+++ b/templates/admin/account/overview.html
@@ -11,7 +11,7 @@
     <div class="select" style="float:right">
         <select v-model="committee">
             <option :value="false">Filtrera på nämnd</option>
-            <option v-for="committee in committees" v-text="committee + ' (' + (expenses.filter(x => x.committees.indexOf(committee) > -1).length) + ')'" :value="committee"></option>
+            <option v-for="committee in committees" v-text="committee + ' (' + expenses.filter(x => x.committees.indexOf(committee) > -1).length + ' + ' + invoices.filter(x => x.committees.indexOf(committee) > -1).length + ')'" :value="committee"></option>
         </select>
     </div>
     <h2>Utlägg</h2>
@@ -172,9 +172,11 @@
             }
         },
         created: function() {
-            this.committees = Array.from(new Set([].concat.apply([], this.expenses.map(x => x.committees))))
-            this.committees.sort((a, b) => a.localeCompare(b, 'sv-SE'));
-            console.log(this.expenses)
+            this.committees = Array.from(new Set([
+                ...this.expenses.flatMap(x => x.committees),
+                ...this.invoices.flatMap(x => x.committees),
+            ]))
+            this.committees.sort((a, b) => a.localeCompare(b, 'sv-SE'))
         }
     })
 </script>

--- a/templates/admin/pay/overview.html
+++ b/templates/admin/pay/overview.html
@@ -17,7 +17,7 @@
     <div class="select" style="margin-left: 10px;float:right">
         <select v-model="committee">
             <option :value="false">Filtrera på nämnd</option>
-            <option v-for="committee in committees" v-text="committee + ' (' + (expenses.filter(x => x.committees.indexOf(committee) > -1).length) + ')'" :value="committee"></option>
+            <option v-for="committee in committees" v-text="committee + ' (' + expenses.filter(x => x.committees.indexOf(committee) > -1).length + ' + ' + invoices.filter(x => x.committees.indexOf(committee) > -1).length + ')'" :value="committee"></option>
         </select>
     </div>
     <div class="clearfix"></div>
@@ -193,8 +193,11 @@
             },
         },
         created: function() {
-            this.committees = Array.from(new Set([].concat.apply([], this.expenses.map(x => x.committees))))
-            this.committees.sort((a, b) => a.localeCompare(b, 'sv-SE'));
+            this.committees = Array.from(new Set([
+                ...this.expenses.flatMap(x => x.committees),
+                ...this.invoices.flatMap(x => x.committees),
+            ]))
+            this.committees.sort((a, b) => a.localeCompare(b, 'sv-SE'))
             document.getElementById('cover').style.display = 'flex'
 
             document.addEventListener('keyup', (e) => {


### PR DESCRIPTION
On the accounting and payment admin pages, you can filter on committees, but only the committees having at least one expense were shown. Now you can also filter on those that only have invoices in the list.