### PR TITLE
Use transactions when creating expenses

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,9 @@ services:
         - path: Pipfile
           action: rebuild
     command: sh -c "pipenv run ./manage.py migrate && pipenv run ./manage.py runserver 0.0.0.0:8000"
+    depends_on:
+      db:
+        condition: service_healthy
   db:
     image: postgres:14
     environment:


### PR DESCRIPTION
If an expense is created but then creating one of the files or expense parts fails we get an expense without any of the files or parts. This makes failing expenses not be stored in the database at all.

Testen in production
![image](https://github.com/datasektionen/cashflow/assets/32957299/77b21c72-9aa1-4e5c-a229-cb4f41285074)