### PR TITLE
Handle error when file is too big

### DIFF
--- a/expenses/urls.py
+++ b/expenses/urls.py
@@ -32,7 +32,7 @@ urlpatterns = [
     url(r'^(?P<pk>\d+)/edit/$', views.edit_expense, name='expenses-edit'),
     url(r'^(?P<pk>\d+)/delete/$', views.delete_expense, name='expenses-delete'),
     url(r'^(?P<expense_pk>\d+)/comment/$', views.new_comment, name='expenses-comment'),
-    
+
     url(r'^api/payment/new/$', views.api_new_payment, name='expenses-api-payment-new'),
     url(r'^payment/new/$', views.new_payment, name='expenses-payment-new'),
     url(r'^payment/(?P<pk>\d+)/$', views.get_payment, name='expenses-payment'),

--- a/file_api/views.py
+++ b/file_api/views.py
@@ -44,9 +44,6 @@ def pretty_request(request):
 @require_http_methods(["POST"])
 @csrf_exempt
 def new_file(request):
-    if len((request.FILES.getlist('files'))) < 1:
-        return JsonResponse({'message':'No file specified.','explanation':'Upload at least one file.'}, status=400)
-
     eId = int(request.GET.get('expense', '0'))
     expense = None
     if eId > 0:
@@ -55,28 +52,24 @@ def new_file(request):
         expense.confirmed_at = None
         expense.save()
 
-    # Upload the file
-    files = []
-    for uploaded_file in request.FILES.getlist('files'):
-        if uploaded_file.content_type in ['image/heif', 'image/heic'] :
-            img = BytesIO()
-            with Image.open(uploaded_file) as im:
-                im.save(img, format="jpeg")
-            uploaded_file = InMemoryUploadedFile(
-                img,
-                None,
-                uploaded_file.name.lower().replace(".heic", ".jpeg"),
-                "image/jpeg",
-                img.getbuffer().nbytes,
-                "binary"
-            )
+    uploaded_file = request.FILES["file"]
+    if uploaded_file.content_type in ['image/heif', 'image/heic'] :
+        img = BytesIO()
+        with Image.open(uploaded_file) as im:
+            im.save(img, format="jpeg")
+        uploaded_file = InMemoryUploadedFile(
+            img,
+            None,
+            uploaded_file.name.lower().replace(".heic", ".jpeg"),
+            "image/jpeg",
+            img.getbuffer().nbytes,
+            "binary"
+        )
 
-        file = File(file=uploaded_file, expense=expense)
-        file.save()
+    file = File(file=uploaded_file, expense=expense)
+    file.save()
 
-        files.append(file)
-
-    return JsonResponse({'message':'File uploaded.', 'files':[file.to_dict() for file in files]})
+    return JsonResponse({"message": "File uploaded", "file": file.to_dict()})
 
 @require_http_methods(["POST"])
 @csrf_exempt

--- a/templates/expenses/new.html
+++ b/templates/expenses/new.html
@@ -237,41 +237,45 @@
             deleteFile: function(file) {
                 this.files = this.files.filter(f => f !== file)
             },
-            upload: function(formData, file) {
-                this.files.push({
+            upload: async function(formData, file) {
+                const fileThing = {
                     name: file.name,
                     file: file,
                     status: 0
-                })
+                };
+                this.files.push(fileThing);
 
-                fetch('/api/files/new/', {
-                    method: 'POST',
-                    body: formData,
-                    credentials: 'same-origin'
-                })
-                    .then(x => x.json())
-                    .catch(x => console.error("Error", x))
-                    .then(x => {
-                        this.files = this.files.map(f => {
-                            if (f.file === file) {
-                                f.status = 1
-                                f.url = x.files[0].url
-                                f.id = x.files[0].id
-                                f.isImg = f.url.endsWith('.jpg')
-                                       || f.url.endsWith('.png')
-                                       || f.url.endsWith('.jpeg')
-                                       || f.url.endsWith('.gif')
-                            }
-                            console.error(f)
-                            return f
-                        })
-                    })
-                    .catch(x => console.error("Error", x))
+                try {
+                    const res = await fetch('/api/files/new/', {
+                        method: 'POST',
+                        body: formData,
+                        credentials: 'same-origin'
+                    });
+                    if (res.status === 413) { // "Request Entity Too Large"
+                        const index = this.files.findIndex(f => f == fileThing);
+                        this.files.splice(index, 1);
+                        // Of course MiB is the superior measurement, but nginx
+                        // is only configurable in mega, not mibi according to
+                        // the documentation, but that may of course be a lie.
+                        alert(`The provided file is ${Math.ceil(formData.get("files").size / 1000 / 1000)}MB. The maximum allowed size is 100MB`);
+                        return;
+                    }
+                    const json = await res.json();
+                    fileThing.status = 1;
+                    fileThing.url = json.file.url;
+                    fileThing.id = json.file.id;
+                    fileThing.isImg = json.file.url.endsWith(".jpg")
+                                   || json.file.url.endsWith(".png")
+                                   || json.file.url.endsWith(".jpeg")
+                                   || json.file.url.endsWith(".gif");
+                } catch (err) {
+                    console.error(err);
+                }
             },
             uploadFiles: function(droppedFiles) {
                 Array.prototype.forEach.call(droppedFiles, (file) => {
                     const formData = new FormData()
-                    formData.append('files', file, file.name)
+                    formData.set("file", file, file.name)
                     this.upload(formData, file)
                 })
             },


### PR DESCRIPTION
If a file is too big (currently >100MB, as enforced by nginx), the frontend will ignore log that an error occurred but not show any error. Then when submitting the expense form that will fail with a 500.

This alerts to the user that the file was too big, how big it was and the maximum allowed size as is currently configured (although that could drift).