### PR TITLE
fix: names can now be shown properly across the site

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -189,6 +189,13 @@ configs:
           first_name: Martin
           family_name: Median
           year_tag: Me-00
+        - ug_kth_id: yet-another-other-id
+          kth_id: jobjav
+          email: jobjav@kth.se
+          first_name: Jobbig
+          family_name: "\"Speciell\" Jävel"
+          year_tag: B-99
+
 
       hive:
         tokens:

--- a/templates/main.html
+++ b/templates/main.html
@@ -90,7 +90,7 @@
         system_name: "Cashflow",
         color_scheme: "money_green",
         {% if user.is_authenticated %}
-            login_text: "{{ user.get_full_name }}",
+            login_text: "{{ user.get_full_name|escapejs }}", // escapejs is unsafe if 'login_text' is ever used as raw html. So future d-Sys should not allow people to be named XCC names
             login_href: "{% url 'user-show' user.username %}",
         {% else %}
             login_text: "Logga in",

--- a/templates/main.html
+++ b/templates/main.html
@@ -90,7 +90,7 @@
         system_name: "Cashflow",
         color_scheme: "money_green",
         {% if user.is_authenticated %}
-            login_text: "{{ user.get_full_name|escapejs }}", // escapejs is unsafe if 'login_text' is ever used as raw html. So future d-Sys should not allow people to be named XSS names
+            login_text: "{{ user.get_full_name|escapejs }}",
             login_href: "{% url 'user-show' user.username %}",
         {% else %}
             login_text: "Logga in",

--- a/templates/main.html
+++ b/templates/main.html
@@ -90,7 +90,7 @@
         system_name: "Cashflow",
         color_scheme: "money_green",
         {% if user.is_authenticated %}
-            login_text: "{{ user.get_full_name|escapejs }}", // escapejs is unsafe if 'login_text' is ever used as raw html. So future d-Sys should not allow people to be named XCC names
+            login_text: "{{ user.get_full_name|escapejs }}", // escapejs is unsafe if 'login_text' is ever used as raw html. So future d-Sys should not allow people to be named XSS names
             login_href: "{% url 'user-show' user.username %}",
         {% else %}
             login_text: "Logga in",


### PR DESCRIPTION
fixes #290

I fixed so my name (Karl-Isac "KI" Åström) is shown without the quotes being displayed as parsed to &quote-whatever.