### PR TITLE
Sorts verifications in decending order

### DIFF
--- a/admin/views.py
+++ b/admin/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.db.models import IntegerField, Case, When, Value
-from django.db.models.functions import Cast, Substr, Trim, Upper, Replace
+from django.db.models.functions import Cast, Substr, Trim, Upper, Replace, Coalesce
 from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponseBadRequest, JsonResponse, Http404
 from django.shortcuts import render
 from django.urls import reverse
@@ -433,47 +433,88 @@ def list_verification(request):
     if series not in ['ALL', 'E', 'U']:
         series = 'ALL'
 
-    verification_list = Expense.objects \
-        .filter(expense_date__year=year) \
-        .exclude(verification__isnull=True) \
-        .annotate(
-            verification_trimmed=Trim('verification'),
-            verification_compact=Replace(
-                Upper(
-                    Replace(
+    def apply_verification_filters(queryset):
+        queryset = queryset \
+            .exclude(verification__isnull=True) \
+            .annotate(
+                verification_trimmed=Trim('verification'),
+                verification_compact=Replace(
+                    Upper(
                         Replace(
-                            Replace(Trim('verification'), Value(' '), Value('')),
-                            Value('\xa0'),
+                            Replace(
+                                Replace(Trim('verification'), Value(' '), Value('')),
+                                Value('\xa0'),
+                                Value('')
+                            ),
+                            Value('\t'),
                             Value('')
-                        ),
-                        Value('\t'),
-                        Value('')
-                    )
+                        )
+                    ),
+                    Value('\r'),
+                    Value('')
                 ),
-                Value('\r'),
-                Value('')
-            ),
-        ) \
-        .exclude(verification_trimmed__regex=r'^\s*$') \
-        .annotate(
-            verification_priority=Case(
-                When(verification_compact__regex=r'^[EU][0-9]+$', then=Value(1)),
-                default=Value(0),
-                output_field=IntegerField()
-            ),
-            verification_number=Case(
-                When(verification_compact__regex=r'^[EU][0-9]+$', then=Cast(Substr('verification_compact', 2), IntegerField())),
-                default=Value(-1),
-                output_field=IntegerField()
+            ) \
+            .exclude(verification_trimmed__regex=r'^\s*$') \
+            .annotate(
+                verification_priority=Case(
+                    When(verification_compact__regex=r'^[EU][0-9]+$', then=Value(1)),
+                    default=Value(0),
+                    output_field=IntegerField()
+                ),
+                verification_number=Case(
+                    When(verification_compact__regex=r'^[EU][0-9]+$', then=Cast(Substr('verification_compact', 2), IntegerField())),
+                    default=Value(-1),
+                    output_field=IntegerField()
+                )
             )
-        ) \
-        .order_by('verification_priority', '-verification_number', 'verification_compact', '-id') \
-        .all()
 
-    if series == 'E':
-        verification_list = verification_list.filter(verification_compact__regex=r'^E[0-9]+$')
-    elif series == 'U':
-        verification_list = verification_list.filter(verification_compact__regex=r'^U[0-9]+$')
+        if series == 'E':
+            queryset = queryset.filter(verification_compact__regex=r'^E[0-9]+$')
+        elif series == 'U':
+            queryset = queryset.filter(verification_compact__regex=r'^U[0-9]+$')
+
+        return queryset
+
+    verification_list = []
+
+    for expense in apply_verification_filters(
+        Expense.objects.filter(expense_date__year=year)
+    ).order_by('verification_priority', '-verification_number', 'verification_compact', '-id'):
+        verification_list.append({
+            'id': expense.id,
+            'verification': expense.verification,
+            'description': expense.description,
+            'owner_label': str(expense.owner),
+            'owner_href': reverse('user-show', kwargs={'username': expense.owner.user.username}),
+            'date': expense.expense_date,
+            'href': reverse('expenses-show', kwargs={'pk': expense.id}),
+            'verification_priority': expense.verification_priority,
+            'verification_number': expense.verification_number,
+            'verification_compact': expense.verification_compact,
+        })
+
+    for invoice in apply_verification_filters(
+        Invoice.objects.annotate(verification_date=Coalesce('invoice_date', 'created_date')).filter(verification_date__year=year)
+    ).order_by('verification_priority', '-verification_number', 'verification_compact', '-id'):
+        verification_list.append({
+            'id': invoice.id,
+            'verification': invoice.verification,
+            'description': invoice.description,
+            'owner_label': str(invoice.owner),
+            'owner_href': reverse('user-show', kwargs={'username': invoice.owner.user.username}),
+            'date': invoice.invoice_date or invoice.created_date,
+            'href': reverse('invoices-show', kwargs={'pk': invoice.id}),
+            'verification_priority': invoice.verification_priority,
+            'verification_number': invoice.verification_number,
+            'verification_compact': invoice.verification_compact,
+        })
+
+    verification_list.sort(key=lambda item: (
+        item['verification_priority'],
+        -item['verification_number'],
+        item['verification_compact'],
+        -item['id']
+    ))
 
     paginator = Paginator(verification_list, 50)
     page = request.GET.get('page')
@@ -486,7 +527,7 @@ def list_verification(request):
         verifications = paginator.page(paginator.num_pages)
 
     return render(request, 'admin/list-verification.html', {
-        'expenses': verifications,
+        'verifications': verifications,
         'years': years,
         'year': year,
         'series': series,

--- a/admin/views.py
+++ b/admin/views.py
@@ -475,7 +475,7 @@ def list_verification(request):
     elif series == 'U':
         verification_list = verification_list.filter(verification_compact__regex=r'^U[0-9]+$')
 
-    paginator = Paginator(verification_list, 25)
+    paginator = Paginator(verification_list, 50)
     page = request.GET.get('page')
 
     try:

--- a/admin/views.py
+++ b/admin/views.py
@@ -6,7 +6,8 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.db.models.functions import Length
+from django.db.models import IntegerField, Case, When, Value
+from django.db.models.functions import Cast, Substr, Trim, Upper, Replace
 from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponseBadRequest, JsonResponse, Http404
 from django.shortcuts import render
 from django.urls import reverse
@@ -425,13 +426,54 @@ def search_verification_response(request):
 def list_verification(request):
     years = range(2017, datetime.now().year + 1)
     year = request.GET.get('year')
+    series = request.GET.get('series')
 
     year = year if year is not None and year != '' else datetime.now().year
+    series = series.upper() if series is not None and series != '' else 'ALL'
+    if series not in ['ALL', 'E', 'U']:
+        series = 'ALL'
 
     verification_list = Expense.objects \
-        .filter(expense_date__year=year, verification__regex=r'E') \
-        .order_by(Length('verification').asc(), 'verification') \
+        .filter(expense_date__year=year) \
+        .exclude(verification__isnull=True) \
+        .annotate(
+            verification_trimmed=Trim('verification'),
+            verification_compact=Replace(
+                Upper(
+                    Replace(
+                        Replace(
+                            Replace(Trim('verification'), Value(' '), Value('')),
+                            Value('\xa0'),
+                            Value('')
+                        ),
+                        Value('\t'),
+                        Value('')
+                    )
+                ),
+                Value('\r'),
+                Value('')
+            ),
+        ) \
+        .exclude(verification_trimmed__regex=r'^\s*$') \
+        .annotate(
+            verification_priority=Case(
+                When(verification_compact__regex=r'^[EU][0-9]+$', then=Value(1)),
+                default=Value(0),
+                output_field=IntegerField()
+            ),
+            verification_number=Case(
+                When(verification_compact__regex=r'^[EU][0-9]+$', then=Cast(Substr('verification_compact', 2), IntegerField())),
+                default=Value(-1),
+                output_field=IntegerField()
+            )
+        ) \
+        .order_by('verification_priority', '-verification_number', 'verification_compact', '-id') \
         .all()
+
+    if series == 'E':
+        verification_list = verification_list.filter(verification_compact__regex=r'^E[0-9]+$')
+    elif series == 'U':
+        verification_list = verification_list.filter(verification_compact__regex=r'^U[0-9]+$')
 
     paginator = Paginator(verification_list, 25)
     page = request.GET.get('page')
@@ -447,6 +489,7 @@ def list_verification(request):
         'expenses': verifications,
         'years': years,
         'year': year,
+        'series': series,
     })
 
 

--- a/admin/views.py
+++ b/admin/views.py
@@ -424,7 +424,7 @@ def search_verification_response(request):
 @login_required
 @user_passes_test(lambda u: u.profile.is_admin())
 def list_verification(request):
-    years = range(2017, datetime.now().year + 1)
+    years = range(datetime.now().year, 2016, -1)
     year = request.GET.get('year')
     series = request.GET.get('series')
 

--- a/staticfiles/style.css
+++ b/staticfiles/style.css
@@ -542,6 +542,21 @@ input[type="date"], input[type="time"] {
     text-overflow: '';
     padding: 0 20px 0 7px;
 }
+#verification-filters .year-select {
+    min-width: 80px;
+}
+
+#verification-filters .year-select select {
+    width: 100%;
+}
+
+#verification-filters .series-select {
+    min-width: 70px;
+}
+
+#verification-filters .series-select select {
+    width: 100%;
+}
 #content table.card tbody tr {
     background: #fff;
     border-bottom: 1px solid #efefef;

--- a/templates/admin/list-verification.html
+++ b/templates/admin/list-verification.html
@@ -5,12 +5,21 @@
 
 {% block content %}
     <div id="app">
-        <div class="select">
+        <div id="verification-filters" class="filters-row">
+        <div class="select year-select">
             <select v-model="year" v-on:change="move">
                 {% for year in years %}
                     <option :value="{{ year }}">{{ year }}</option>
                 {% endfor %}
             </select>
+        </div>
+        <div class="select series-select">
+            <select v-model="series" v-on:change="move">
+                <option value="ALL">Alla</option>
+                <option value="E">E</option>
+                <option value="U">U</option>
+            </select>
+        </div>
         </div>
         <div class="clear"></div>
         <br/>
@@ -42,16 +51,16 @@
             <div class="pagination">
         <span class="step-links">
             {% if expenses.has_previous %}
-                <a href="?page={{ expenses.previous_page_number }}&year={{ year }}">Föregående</a>
+                <a href="?page={{ expenses.previous_page_number }}&year={{ year }}&series={{ series }}">Föregående</a>
             {% endif %}
 
             {% for i in expenses.paginator.page_range %}
-                <a href="?page={{ i }}&year={{ year }}" {% if i == expenses.number %}
+                <a href="?page={{ i }}&year={{ year }}&series={{ series }}" {% if i == expenses.number %}
                    class="active"{% endif %}>{{ i }}</a>
             {% endfor %}
 
             {% if expenses.has_next %}
-                <a href="?page={{ expenses.next_page_number }}&year={{ year }}">Nästa</a>
+                <a href="?page={{ expenses.next_page_number }}&year={{ year }}&series={{ series }}">Nästa</a>
             {% endif %}
         </span>
             </div>
@@ -65,11 +74,14 @@
             data: function () {
                 return {
                     year: {% autoescape off %} {{ year }} {% endautoescape %},
+                    series: "{{ series }}",
                 }
             },
             methods: {
                 move() {
                     this.params.set('year', this.year)
+                    this.params.set('series', this.series)
+                    this.params.delete('page')
                     window.location.href = `?${this.params.toString()}`
                 }
             },

--- a/templates/admin/list-verification.html
+++ b/templates/admin/list-verification.html
@@ -23,7 +23,7 @@
         </div>
         <div class="clear"></div>
         <br/>
-        {% if expenses %}
+        {% if verifications %}
             <table>
                 <thead>
                     <th>Ver.nr.</th>
@@ -31,36 +31,36 @@
                     <th>Ägare</th>
                     <th>Inköpsdatum</th>
                 </thead>
-                {% for expense in expenses %}
+                {% for verification in verifications %}
                     <tr>
-                        <td><a href="{% url 'expenses-show' expense.id %}">{{ expense.verification }}</a></td>
-                        <td><a href="{% url 'expenses-show' expense.id %}">{{ expense.description|capfirst }}</a></td>
+                        <td><a href="{{ verification.href }}">{{ verification.verification }}</a></td>
+                        <td><a href="{{ verification.href }}">{{ verification.description|capfirst }}</a></td>
                         <td class="no-wrap"><a
-                                href="{% url 'user-show' expense.owner.user.username %}">{{ expense.owner }}</a></td>
-                        <td>{{ expense.expense_date }}</td>
+                                href="{{ verification.owner_href }}">{{ verification.owner_label }}</a></td>
+                        <td>{{ verification.date }}</td>
                     </tr>
                 {% endfor %}
                 <tfoot>
                 <tr>
                     <td class="right" colspan="4">
-                        <span class="current">Sida {{ expenses.number }} av {{ expenses.paginator.num_pages }}</span>
+                        <span class="current">Sida {{ verifications.number }} av {{ verifications.paginator.num_pages }}</span>
                     </td>
                 </tr>
                 </tfoot>
             </table>
             <div class="pagination">
         <span class="step-links">
-            {% if expenses.has_previous %}
-                <a href="?page={{ expenses.previous_page_number }}&year={{ year }}&series={{ series }}">Föregående</a>
+            {% if verifications.has_previous %}
+                <a href="?page={{ verifications.previous_page_number }}&year={{ year }}&series={{ series }}">Föregående</a>
             {% endif %}
 
-            {% for i in expenses.paginator.page_range %}
-                <a href="?page={{ i }}&year={{ year }}&series={{ series }}" {% if i == expenses.number %}
+            {% for i in verifications.paginator.page_range %}
+                <a href="?page={{ i }}&year={{ year }}&series={{ series }}" {% if i == verifications.number %}
                    class="active"{% endif %}>{{ i }}</a>
             {% endfor %}
 
-            {% if expenses.has_next %}
-                <a href="?page={{ expenses.next_page_number }}&year={{ year }}&series={{ series }}">Nästa</a>
+            {% if verifications.has_next %}
+                <a href="?page={{ verifications.next_page_number }}&year={{ year }}&series={{ series }}">Nästa</a>
             {% endif %}
         </span>
             </div>

--- a/templates/admin/search-verification.html
+++ b/templates/admin/search-verification.html
@@ -7,10 +7,58 @@
 <div id="app">
     <input type="text" v-on:keyup="search" v-model="query" placeholder="Skriv ett verifikationsnummer att söka efter..." />
     <ul class="search-result">
-        <li v-for="invoice in invoices"><a :href="'/invoices/' + invoice.id" v-text="invoice.verification + ': Faktura ' + invoice.description"></a></li>
-        <li v-for="expense in expenses"><a :href="'/expenses/' + expense.id" v-text="expense.verification + ': Utlägg ' + expense.description"></a></li>
+        <li class="search-result-row" v-for="invoice in invoices" :key="`invoice-${invoice.id}`">
+            <a class="search-result-item" :href="'/invoices/' + invoice.id">
+                <span class="search-result-label" v-text="invoice.verification + ': ' + invoice.description"></span>
+                <span class="search-result-year" v-text="getYear(invoice.invoice_date || invoice.created_date)"></span>
+            </a>
+        </li>
+        <li class="search-result-row" v-for="expense in expenses" :key="`expense-${expense.id}`">
+            <a class="search-result-item" :href="'/expenses/' + expense.id">
+                <span class="search-result-label" v-text="expense.verification + ': ' + expense.description"></span>
+                <span class="search-result-year" v-text="getYear(expense.expense_date || expense.created_date)"></span>
+            </a>
+        </li>
     </ul>
 </div>
+<style>
+    .search-result-row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .search-result-item {
+        display: block;
+        position: relative;
+        flex: 1 1 auto;
+        min-width: 0;
+        width: 100%;
+        padding-right: 55px;
+        text-decoration: none;
+    }
+
+    .search-result-item:hover,
+    .search-result-item:focus,
+    .search-result-item:visited {
+        text-decoration: none;
+    }
+
+    .search-result-label {
+        min-width: 0;
+        display: block;
+    }
+
+    .search-result-year {
+        position: absolute;
+        right: 10px;
+        top: 50%;
+        transform: translateY(-50%);
+        color: #696969;
+        text-decoration: none !important;
+        white-space: nowrap;
+    }
+</style>
 <script type="text/javascript">
     new Vue({
         el: '#app', 
@@ -24,6 +72,12 @@
         },
         methods: {
             search() {
+                if (this.query.trim().length < 1) {
+                    this.invoices = []
+                    this.expenses = []
+                    return
+                }
+
                 let form = new FormData()
                 form.append('csrfmiddlewaretoken', '{{ csrf_token }}')
                 form.append('query', this.query)
@@ -39,6 +93,12 @@
                     this.invoices = res.invoices
                     this.expenses = res.expenses
                 })
+            },
+            getYear(dateValue) {
+                if (!dateValue) {
+                    return ''
+                }
+                return String(dateValue).slice(0, 4)
             }
         },
         created: function() {


### PR DESCRIPTION
Sorts verifications in decending order
Fixes problems caused by previously sorting alphabetically (E5 falls between E49 and E50)
Adds option to display only E or U verifications
Puts all verifications with a unrecognized format at the top of the list so that they are easily found and can be changed.