### PR TITLE
feat: clear secondary cc and budget line search values on cost centre change

### DIFF
--- a/frontend/src/lib/components/ClaimFilterBar.svelte
+++ b/frontend/src/lib/components/ClaimFilterBar.svelte
@@ -38,6 +38,13 @@
 
 	let showAllFilters: boolean = $state(true);
 
+	// These bind to the comboboxes search strings, and are used to clear e.g. budget line when cost centre is changed
+	let budgetSearchValues = $state({
+		costCentre: '',
+		secondaryCostCentre: '',
+		budgetLine: ''
+	});
+
 	let costCentres: CostCentre[] = $state([]);
 	let secondaryCostCentres: SecondaryCostCentre[] = $state([]);
 	let budgetLines: BudgetLine[] = $state([]);
@@ -176,6 +183,8 @@
 							.then((res) => res.data)
 					: [];
 			budgetLines = [];
+			budgetSearchValues.secondaryCostCentre = '';
+			budgetSearchValues.budgetLine = '';
 			url.searchParams.delete('secondary_cost_centre');
 			url.searchParams.delete('budget_line');
 		} else if (key === 'secondary_cost_centre') {
@@ -185,6 +194,7 @@
 					? { secondary_cost_centre: secondaryCostCentre.id }
 					: undefined;
 			budgetLines = await api.budget.listBudgetLines(1, 100, filter).then((res) => res.data);
+			budgetSearchValues.budgetLine = '';
 			url.searchParams.delete('budget_line');
 		}
 
@@ -240,6 +250,7 @@
 		<ComboBox
 			class="text-sm"
 			value={filterValue('cost_centre')}
+			bind:searchValue={budgetSearchValues.costCentre}
 			onchange={(v) => setFilter('cost_centre', v)}
 			placeholder={$_('cost_centre')}
 			items={costCentres.map((it) => it.name)}
@@ -247,6 +258,7 @@
 		<ComboBox
 			class="text-sm"
 			value={filterValue('secondary_cost_centre')}
+			bind:searchValue={budgetSearchValues.secondaryCostCentre}
 			onchange={(v) => setFilter('secondary_cost_centre', v)}
 			placeholder={$_('secondary_cost_centre')}
 			items={secondaryCostCentres.map((it) => it.name)}
@@ -254,6 +266,7 @@
 		<ComboBox
 			class="text-sm"
 			value={filterValue('budget_line')}
+			bind:searchValue={budgetSearchValues.budgetLine}
 			onchange={(v) => setFilter('budget_line', v)}
 			placeholder={$_('budget_line')}
 			items={budgetLines.map((it) => it.name)}

--- a/frontend/src/lib/components/ComboBox.svelte
+++ b/frontend/src/lib/components/ComboBox.svelte
@@ -14,6 +14,7 @@ Wraps bits-ui's Combobox component. Supports fuzzy text search using fuse.js.
 		items,
 		placeholder = '',
 		value = $bindable(''),
+		searchValue = $bindable(''),
 		class: className = '',
 		locked = false,
 		onchange,
@@ -23,13 +24,14 @@ Wraps bits-ui's Combobox component. Supports fuzzy text search using fuse.js.
 		items: string[];
 		placeholder?: string;
 		value?: string;
+		searchValue?: string;
 		class?: string;
 		locked?: boolean;
 		onchange?: (value: string) => void;
 		onblur?: (e: FocusEvent) => void;
 	} = $props();
 
-	let searchValue = $state(value ?? '');
+	// let searchValue = $state(value ?? '');
 	let open = $state(false);
 
 	const fuse = $derived(new Fuse(items));

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,5 +1,4 @@
 import { browser, dev } from '$app/environment';
 
-
 const BACKEND_PORT = dev ? 8000 : 8001;
 export const API_URL = browser ? '/api/' : `http://127.0.0.1:${BACKEND_PORT}/api/`;

--- a/frontend/src/routes/admin/vouchers/+page.svelte
+++ b/frontend/src/routes/admin/vouchers/+page.svelte
@@ -104,8 +104,6 @@
 	</span>
 {/snippet}
 
-
-
 <ClaimFilterBar includeChecks={false} />
 
 <PaginatedTable


### PR DESCRIPTION
When you change the cost centre when filtering the search values for secondary cost centres and budget lines will also be cleared (same goes for changing secondary cost centres and clearing budget line). Achieved by making the search value bindable in the ComboBox component.

Resolves #338 