### PR TITLE
fix: allow larger client body size in nginx

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,8 @@
 events {}
 
 http {
+  client_max_body_size 25M;
+
   server {
     listen 8000;
 


### PR DESCRIPTION
Should allow files larger than 1MB to be uploaded