### PR TITLE
fix: PDF display on confirm page

### DIFF
--- a/frontend/src/lib/components/ReceiptViewer.svelte
+++ b/frontend/src/lib/components/ReceiptViewer.svelte
@@ -33,22 +33,24 @@ render. Accepts one or more url sources, of either kind, mixed or not.
 	{/each}
 
 	{#if pdfSources.length > 0}
-		<PDFViewer
-			config={{
-				documentManager: {
-					initialDocuments: pdfSources.map((s, i) => ({
-						url: s,
-						name: (i + 1).toString()
-					}))
-				},
-				tabBar: pdfSources.length > 1 ? 'multiple' : 'never',
-				theme: { preference: 'system' },
-				disabledCategories: ['annotation', 'redaction', 'search'],
-				zoom: { defaultZoomLevel: ZoomMode.FitWidth },
-				scroll: { defaultStrategy: ScrollStrategy.Vertical },
-				i18n: { defaultLocale: $locale ?? 'sv', fallbackLocale: 'en' }
-			}}
-			style="width: 100%; height: 100%"
-		/>
+		<div class="h-[80dvh] w-full shrink-0">
+			<PDFViewer
+				config={{
+					documentManager: {
+						initialDocuments: pdfSources.map((s, i) => ({
+							url: s,
+							name: (i + 1).toString()
+						}))
+					},
+					tabBar: pdfSources.length > 1 ? 'multiple' : 'never',
+					theme: { preference: 'system' },
+					disabledCategories: ['annotation', 'redaction', 'search'],
+					zoom: { defaultZoomLevel: ZoomMode.FitWidth },
+					scroll: { defaultStrategy: ScrollStrategy.Vertical },
+					i18n: { defaultLocale: $locale ?? 'sv', fallbackLocale: 'en' }
+				}}
+				style="width: 100%; height: 100%"
+			/>
+		</div>
 	{/if}
 </div>

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,13 @@
 events {}
 
 http {
+  # Send logs to the container's stdout/stderr so supervisord forwards them to
+  # Grafana. Without this nginx writes to files under /var/log/nginx and its
+  # access/error logs (the only place edge failures like 502s are visible) never
+  # get collected.
+  access_log /dev/stdout;
+  error_log /dev/stderr warn;
+
   client_max_body_size 25M;
 
   server {


### PR DESCRIPTION
Also make nginx send logs to stdout/err so errors like request body size limits might be easier to catch in the future.