### PR TITLE
fix: link issues on IOS

### DIFF
--- a/backend/users/api/urls.py
+++ b/backend/users/api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path("", views.UserListView.as_view(), name="users_list"),
     path("me/", views.CurrentUserView.as_view(), name="current-user"),
     path(
         "profile-pictures/", views.ProfilePictureView.as_view(), name="profile-pictures"

--- a/backend/users/api/views.py
+++ b/backend/users/api/views.py
@@ -4,9 +4,16 @@ from django.utils.module_loading import import_string
 from drf_spectacular.utils import extend_schema_view, extend_schema, inline_serializer
 from rest_framework import generics, exceptions, status, serializers
 from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from django.contrib.auth.models import User
+from core.api.pagination import DefaultPagination
 
 from .serializers import UserSerializer, ProfilePictureQuerySerializer
 from ..pictures import ProfilePictureProvider
+from core.permissions import get_permission_provider
+from core.api.utils import AuthenticatedUserMixin
 
 profile_picture_provider: ProfilePictureProvider = import_string(
     settings.PROFILE_PICTURE_PROVIDER
@@ -90,3 +97,28 @@ class ProfilePictureView(generics.ListAPIView):
             result.update(fetched)
 
         return Response(result)
+
+
+@extend_schema(
+    summary="List users",
+    tags=["Users"],
+    operation_id="list_users",
+    description="Lists all users.",
+)
+class UserListView(APIView, AuthenticatedUserMixin):
+
+    def get(self, request: Request) -> Response:
+        permissions = get_permission_provider()
+
+        if not (
+            permissions.may_pay(self.current_user)
+            or permissions.may_view_all(self.current_user)
+        ):
+            raise PermissionDenied()
+
+        users = User.objects.order_by("username")
+        pagination = DefaultPagination()
+        page = pagination.paginate_queryset(users, request, view=self)
+        serializer = UserSerializer(page, many=True)
+
+        return pagination.get_paginated_response(serializer.data)

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -5,6 +5,8 @@ from rest_framework.test import APIClient
 
 from users.pictures import ProfilePictureProvider, ProfilePicture
 
+from cashflow.dauth import Permission
+
 
 class FakeProfilePictureProvider(ProfilePictureProvider):
 
@@ -179,3 +181,29 @@ class TestHasBankInfo:
     def test_bank_name_alone_is_not_enough(self, profile):
         profile.bank_name = "Swedbank"
         assert profile.has_bank_info is False
+
+
+class TestUserListPermissions:
+
+    def test_normal_user_gets_403(self, api_client, mocker):
+        mocker.patch("cashflow.dauth.get_permissions", return_value={}, autospec=True)
+        response = api_client.get("/api/users/")
+        assert response.status_code == 403
+
+    def test_user_with_pay_permissions(self, api_client, mocker):
+        mocker.patch(
+            "cashflow.dauth.get_permissions",
+            return_value={Permission.PAY: True},
+            autospec=True,
+        )
+        response = api_client.get("/api/users/")
+        assert response.status_code == 200
+
+    def test_user_with_view_all_permissions(self, api_client, mocker):
+        mocker.patch(
+            "cashflow.dauth.get_permissions",
+            return_value={Permission.VIEW_ALL: True},
+            autospec=True,
+        )
+        response = api_client.get("/api/users/")
+        assert response.status_code == 200

--- a/frontend/src/lib/components/PaginatedTable.svelte
+++ b/frontend/src/lib/components/PaginatedTable.svelte
@@ -10,6 +10,7 @@ A table that accepts either a paginated response or other data. Uses bits-ui Pag
 	import { _ } from 'svelte-i18n';
 	import CashSpinner from '$lib/components/CashSpinner.svelte';
 	import { isSmallLayout } from '$lib/stores/state.svelte';
+	import { goto } from '$app/navigation';
 
 	interface Props {
 		paginatedResponse?: PaginatedResponse<T>;
@@ -47,6 +48,29 @@ A table that accepts either a paginated response or other data. Uses bits-ui Pag
 		return typeof c === 'function' ? c(row) : c;
 	}
 
+
+	function handleRowClick(e: MouseEvent, row: T) {
+		if ((e.target as HTMLElement).closest('a, button')) return;
+		if (rowProps?.href) {
+			const href = rowProps.href(row);
+			if (e.metaKey || e.ctrlKey || e.shiftKey) {
+				window.open(href, '_blank', 'noopener');
+			} else if (!e.altKey) {
+				goto(href);
+			}
+		} else {
+			rowProps?.onClick?.(row);
+		}
+	}
+
+	function handleRowAuxClick(e: MouseEvent, row: T) {
+		if (e.button !== 1) return;
+		if ((e.target as HTMLElement).closest('a, button')) return;
+		if (rowProps?.href) {
+			window.open(rowProps.href(row), '_blank', 'noopener');
+		}
+	}
+
 	const rangeStart = $derived(
 		resolved.pagination.total === 0
 			? 0
@@ -77,29 +101,15 @@ A table that accepts either a paginated response or other data. Uses bits-ui Pag
 						<tr
 							class={[
 								'h-12 border-b border-b-base-400 hover:bg-base-200 dark:border-dark-base-150 dark:hover:bg-dark-base-200',
-								rowProps?.href && 'relative isolate',
 								resolveRowClass(row)
 							]}
-							onclick={rowProps?.onClick ? () => rowProps.onClick?.(row) : undefined}
+							onclick={(e) => handleRowClick(e, row)}
+							onauxclick={(e) => handleRowAuxClick(e, row)}
 						>
 							{#each columns as column, ci}
-								<td
-									class={[
-										'px-4',
-										// The first cell hosts the stretched row link, so it must not clip
-										// the overlay; every other cell keeps overflow-hidden for truncation.
-										ci === 0 && rowProps?.href ? '' : 'overflow-hidden',
-										!column.renderSnippet && 'truncate'
-									]}
-								>
+								<td class={['px-4 overflow-hidden', !column.renderSnippet && 'truncate']}>
 									{#if ci === 0 && rowProps?.href}
-										<!-- The ::before overlay covers the whole row (the <tr> is the
-										     positioning context). Interactive cell content is elevated
-										     with z-10 so it stays clickable above the overlay. -->
-										<a
-											href={rowProps.href(row)}
-											class="before:absolute before:inset-0 before:content-['']"
-										>
+										<a href={rowProps.href(row)}>
 											{#if column.renderSnippet}
 												{@render column.renderSnippet(row)}
 											{:else}


### PR DESCRIPTION
This should fix all rows linking to the same expense on a user's expense list on iOS. (Bonus user list endpoint for future use.) 